### PR TITLE
all tests failing, left as is

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -111,3 +111,4 @@ Fix:
 
 ### Closing
 - attempting to run tests
+- found tests were failing on reset, LAI


### PR DESCRIPTION
bin/rails test:all shows multiple test failures (also reset to before changes to verify)